### PR TITLE
Feature/add equals to method to tco object

### DIFF
--- a/pipelines/azure-pipelines.yaml
+++ b/pipelines/azure-pipelines.yaml
@@ -6,7 +6,7 @@ queue:
 steps:
 - powershell : > 
     ./pipelines/runbuild.ps1 -properties @{     
-     "publishNugets"=$true;
+     "publishNugets"=$false;
      "updateAssemblyInfo" = $true;
      "isTestingEnabled" = $true
      }   

--- a/src/TcoCore/src/XaeTcoCore/TcoCore/POUs/Prototypes/TcoObject/TcoObject.TcPOU
+++ b/src/TcoCore/src/XaeTcoCore/TcoCore/POUs/Prototypes/TcoObject/TcoObject.TcPOU
@@ -116,8 +116,9 @@ END_VAR
 			When overriden in derived class custom comparison of two objects of the same type can be evaluated.						
  		</summary>			
 		<note>
-			Default implementation compares if two objects by reference. If you want you compare actual values of the objects
-			you will need to override ```EqualsTo``` method where you evaluate the values for equality.
+			Default implementation compares only if two objects share the same reference. 
+			If you want to compare actual values of the objects you will need to override EqualsTo method, 
+			where you evaluate the values for equality.
 		</note>
 		<example>
 			<code>

--- a/src/TcoCore/src/XaeTcoCore/TcoCoreTests/Tests/TcoObject/TcoObjectTest.TcPOU
+++ b/src/TcoCore/src/XaeTcoCore/TcoCoreTests/Tests/TcoObject/TcoObjectTest.TcPOU
@@ -54,7 +54,7 @@ END_VAR]]></Declaration>
 	0:
 		referenceTo_TcoStateTest_A REF= _TcoStateTest_A;
 		EqualsTest := _TcoStateTest_A.EqualsTo(referenceTo_TcoStateTest_A);
-    1:	
+	1:	
 		EqualsTest := _TcoStateTest_A.EqualsTo(_TcoStateTest_B);
 	2:	
 		EqualsTest := _TcoObjectEqualsTestObj1.EqualsTo(_TcoObjectEqualsTestObj1);

--- a/src/TcoCore/src/XaeTcoCore/TcoCoreTests/Tests/TcoObject/TcoObjectTest.TcPOU
+++ b/src/TcoCore/src/XaeTcoCore/TcoCoreTests/Tests/TcoObject/TcoObjectTest.TcPOU
@@ -43,25 +43,26 @@ METHOD PUBLIC EqualsOverrideTest : BOOL
       <Declaration><![CDATA[{attribute 'TcRpcEnable'}
 METHOD PUBLIC EqualsTest : BOOL
 VAR_INPUT
-	_case : INT;
+    _case : INT;
 END_VAR
 
-VAR 
-	referenceTo_TcoStateTest_A : REFERENCE TO TcoStateTest;
+VAR
+    referenceTo_a_TcoStateTest : REFERENCE TO TcoStateTest;
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[CASE _case OF
-	0:
-		referenceTo_TcoStateTest_A REF= _TcoStateTest_A;
-		EqualsTest := _TcoStateTest_A.EqualsTo(referenceTo_TcoStateTest_A);
-	1:	
-		EqualsTest := _TcoStateTest_A.EqualsTo(_TcoStateTest_B);
-	2:	
-		EqualsTest := _TcoObjectEqualsTestObj1.EqualsTo(_TcoObjectEqualsTestObj1);
-	3:
-		EqualsTest := _TcoObjectEqualsTestObj1.EqualsTo(_TcoObjectEqualsTestObj2);
+    0:
+        referenceTo_a_TcoStateTest REF= _TcoStateTest_A;
+        EqualsTest := _TcoStateTest_A.EqualsTo(referenceTo_a_TcoStateTest);
+    1:
+        EqualsTest := _TcoStateTest_A.EqualsTo(_TcoStateTest_B);
+    4:
+        EqualsTest := _TcoStateTest_B.EqualsTo(_TcoStateTest_A);
+    2:
+        EqualsTest := _TcoObjectEqualsTestObj1.EqualsTo(_TcoObjectEqualsTestObj1);
+    3:
+        EqualsTest := _TcoObjectEqualsTestObj1.EqualsTo(_TcoObjectEqualsTestObj2);
 END_CASE
-
 ]]></ST>
       </Implementation>
     </Method>

--- a/src/TcoCore/tests/TcoCoreUnitTests/TcoObjectTests.cs
+++ b/src/TcoCore/tests/TcoCoreUnitTests/TcoObjectTests.cs
@@ -73,7 +73,8 @@ namespace TcoCoreUnitTests
         public void T300_EqualsTest()
         {
             Assert.IsTrue(tc_A._TcoObjectTest_Misc.EqualsTest(0)); //0 compares to own reference
-            Assert.IsFalse(tc_A._TcoObjectTest_Misc.EqualsTest(1)); //1 compares to other object
+            Assert.IsFalse(tc_A._TcoObjectTest_Misc.EqualsTest(1)); //1 compares to other object (A to B)
+            Assert.IsFalse(tc_A._TcoObjectTest_Misc.EqualsTest(4)); //4 compares to other object (B to A)
             Assert.IsTrue(tc_A._TcoObjectTest_Misc.EqualsTest(2)); //2 compares same object instance
 
             tc_A._TcoObjectTest_Misc._TcoObjectEqualsTestObj1._SomeNumber.Synchron = 1;


### PR DESCRIPTION
I removed the NuGet package publishing at this time to prevent PR (https://github.com/TcOpenGroup/TcOpen/pull/13) checks to create packages on nuget.org each time at check build. (we will reconfigure the release pipeline later).

Suggestions for previous PR #38 from @GISED-Link 
- B.EqualsTo(A)
- Fixed documentation comment for ```EqualsTo``` method