### PR TITLE
Refactoring and clean up

### DIFF
--- a/src/TcoCore/src/XaeTcoCore/TcoCore/POUs/Prototypes/TcoMessage/ITcoMessengerSettings.TcIO
+++ b/src/TcoCore/src/XaeTcoCore/TcoCore/POUs/Prototypes/TcoMessage/ITcoMessengerSettings.TcIO
@@ -3,6 +3,12 @@
   <Itf Name="ITcoMessengerSettings" Id="{6d6b9064-8fe9-0b02-00be-c0f0ff54eeb4}">
     <Declaration><![CDATA[INTERFACE ITcoMessengerSettings
 ]]></Declaration>
+    <Property Name="IsSuspended" Id="{154b3f83-5ad6-0af7-30ee-bb7fbba61c91}">
+      <Declaration><![CDATA[PROPERTY IsSuspended : BOOL]]></Declaration>
+      <Get Name="Get" Id="{f4387df2-7158-0155-1a2d-255a7974d7ab}">
+        <Declaration><![CDATA[]]></Declaration>
+      </Get>
+    </Property>
     <Property Name="MinLevel" Id="{affff53c-8111-0dde-30b4-02bee538a109}">
       <Declaration><![CDATA[PROPERTY MinLevel : eMessageCategory]]></Declaration>
       <Get Name="Get" Id="{229f0b50-4658-067e-0200-914aca38739d}">

--- a/src/TcoCore/src/XaeTcoCore/TcoCore/POUs/Prototypes/TcoMessage/TcoMessenger.TcPOU
+++ b/src/TcoCore/src/XaeTcoCore/TcoCore/POUs/Prototypes/TcoMessage/TcoMessenger.TcPOU
@@ -243,10 +243,11 @@ END_VAR
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF(_Parent <> 0 AND_THEN _Parent.Context <> 0 AND_THEN _Parent.Context.Environment <> 0 AND_THEN _Parent.Context.Environment.Messaging <> 0) THEN
-	IF(Category < THIS^._Parent.Context.Environment.Messaging.MinLevel) THEN
+	IF(Category < THIS^._Parent.Context.Environment.Messaging.MinLevel
+	  OR _Parent.Context.Environment.Messaging.IsSuspended) THEN
 		RETURN;
-	END_IF; 
-		
+	END_IF; 	
+	
 	_mime.PerCycleCount := _mime.PerCycleCount + 1;
 	// Same cycle filter for most important messge.
 	IF(_mime.Cycle = _Parent.Context.StartCycleCount) THEN		 	

--- a/src/TcoCore/src/XaeTcoCore/TcoCore/POUs/Prototypes/TcoMessage/TcoMessengerSettings.TcPOU
+++ b/src/TcoCore/src/XaeTcoCore/TcoCore/POUs/Prototypes/TcoMessage/TcoMessengerSettings.TcPOU
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.6">
   <POU Name="TcoMessengerSettings" Id="{e6a12bea-a5ee-06da-38d8-d4f316d1c513}" SpecialFunc="None">
-    <Declaration><![CDATA[FUNCTION_BLOCK TcoMessengerSettings IMPLEMENTS ITcoMessengerSettings
+    <Declaration><![CDATA[FUNCTION_BLOCK INTERNAL TcoMessengerSettings IMPLEMENTS ITcoMessengerSettings
 VAR
 	_minLevel : eMessageCategory;
 	_isMessagingSuspended : BOOL;	
@@ -10,8 +10,51 @@ END_VAR
     <Implementation>
       <ST><![CDATA[]]></ST>
     </Implementation>
+    <Property Name="IsSuspended" Id="{184432ba-ed30-0ea9-34ef-43a09897d070}">
+      <Declaration><![CDATA[(*~
+	<docu>
+		<summary>
+			Gets wheater the messaging is suspended at this point in program.					
+			<para>
+				See also <see cref="TcoMessengerSettings.Resume()"/>
+			</para>
+			<para>
+				See also <see cref="TcoMessengerSettings.Suspend()"/>
+			</para>
+			<para>
+				See also <see cref="TcoMessengerSettings.MinLevel"/>
+			</para>
+		</summary>			
+	</docu>	
+~*)
+PROPERTY PUBLIC IsSuspended : BOOL]]></Declaration>
+      <Get Name="Get" Id="{084a81d6-66a6-0874-005f-95fe275f2e20}">
+        <Declaration><![CDATA[VAR
+END_VAR
+]]></Declaration>
+        <Implementation>
+          <ST><![CDATA[IsSuspended := _isMessagingSuspended;]]></ST>
+        </Implementation>
+      </Get>
+    </Property>
     <Property Name="MinLevel" Id="{23651bcd-e46c-0710-3196-f31340d2b191}">
-      <Declaration><![CDATA[PROPERTY MinLevel : eMessageCategory]]></Declaration>
+      <Declaration><![CDATA[(*~
+	<docu>
+		<summary>
+			Gets or set minimal messaging level, the objects will post only messages for the levels of this or superior severity.					
+			<para>
+				See also <see cref="TcoMessengerSettings.Resume()"/>
+			</para>
+			<para>
+				See also <see cref="TcoMessengerSettings.Suspend()"/>
+			</para>
+			<para>
+				See also <see cref="TcoMessengerSettings.MinLevel"/>
+			</para>
+		</summary>			
+	</docu>	
+~*)
+PROPERTY PUBLIC MinLevel : eMessageCategory]]></Declaration>
       <Get Name="Get" Id="{a3f8be89-55fd-0145-22e8-3db7665a5a41}">
         <Declaration><![CDATA[VAR
 END_VAR
@@ -30,14 +73,40 @@ END_VAR
       </Set>
     </Property>
     <Method Name="Resume" Id="{456a9fc8-9f8f-0e21-2081-9877f3b9364c}">
-      <Declaration><![CDATA[METHOD PUBLIC Resume : BOOL
+      <Declaration><![CDATA[(*~
+	<docu>
+		<summary>
+			Resumes messaging from the all objects of this context, when the messaging was previously suspended by ```Suspend``` method.					
+			<para>
+				See also <see cref="TcoMessengerSettings.Suspend()"/>
+			</para>
+			<para>
+				See also <see cref="TcoMessengerSettings.MinLevel"/>
+			</para>
+		</summary>			
+	</docu>	
+~*)
+METHOD PUBLIC Resume : BOOL
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[_isMessagingSuspended := FALSE;]]></ST>
       </Implementation>
     </Method>
     <Method Name="Suspend" Id="{ed0d7753-8ddd-0f15-326c-cd14614ece49}">
-      <Declaration><![CDATA[METHOD PUBLIC Suspend
+      <Declaration><![CDATA[(*~
+	<docu>
+		<summary>
+			Suspends messaging from the all objects of this context that would occur from this point in the call tree.						
+			<para>
+				See also <see cref="TcoMessengerSettings.Resume()"/>
+			</para>
+			<para>
+				See also <see cref="TcoMessengerSettings.MinLevel"/>
+			</para>
+		</summary>			
+	</docu>	
+~*)
+METHOD PUBLIC Suspend
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[_isMessagingSuspended := TRUE;

--- a/src/TcoCore/src/XaeTcoCore/TcoCore/POUs/Prototypes/TcoTask/ITcoTask.TcIO
+++ b/src/TcoCore/src/XaeTcoCore/TcoCore/POUs/Prototypes/TcoTask/ITcoTask.TcIO
@@ -35,7 +35,7 @@
 		</summary>			
 	</docu>	
 ~*)
-METHOD Invoke : ITcoTask
+METHOD Invoke : ITcoTaskStatus
 ]]></Declaration>
     </Method>
   </Itf>

--- a/src/TcoCore/src/XaeTcoCore/TcoCore/POUs/Prototypes/TcoTask/ITcoTaskStatus.TcIO
+++ b/src/TcoCore/src/XaeTcoCore/TcoCore/POUs/Prototypes/TcoTask/ITcoTaskStatus.TcIO
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.6">
+  <Itf Name="ITcoTaskStatus" Id="{6341a5e9-539f-07e2-2781-89effa0ed565}">
+    <Declaration><![CDATA[INTERFACE ITcoTaskStatus
+]]></Declaration>
+    <Property Name="Busy" Id="{0f27cd62-9c61-0157-0eeb-42c4f74b66be}">
+      <Declaration><![CDATA[PROPERTY Busy : BOOL]]></Declaration>
+      <Get Name="Get" Id="{ae011746-e617-02b7-243e-e8509384b84f}">
+        <Declaration><![CDATA[]]></Declaration>
+      </Get>
+    </Property>
+    <Property Name="Done" Id="{e7e4f0d2-681c-0127-20a0-25e98eef98f1}">
+      <Declaration><![CDATA[PROPERTY Done : BOOL]]></Declaration>
+      <Get Name="Get" Id="{ad228e2d-55b7-001f-0fb1-ccc8383b9be3}">
+        <Declaration><![CDATA[]]></Declaration>
+      </Get>
+    </Property>
+    <Property Name="Error" Id="{e997df47-5359-0431-0d62-646922dde6fe}">
+      <Declaration><![CDATA[PROPERTY Error : BOOL]]></Declaration>
+      <Get Name="Get" Id="{1c91e88f-586c-08a8-3390-342071b85c00}">
+        <Declaration><![CDATA[]]></Declaration>
+      </Get>
+    </Property>
+  </Itf>
+</TcPlcObject>

--- a/src/TcoCore/src/XaeTcoCore/TcoCore/POUs/Prototypes/TcoTask/TcoTask.TcPOU
+++ b/src/TcoCore/src/XaeTcoCore/TcoCore/POUs/Prototypes/TcoTask/TcoTask.TcPOU
@@ -29,7 +29,7 @@
 		</example>
 	</docu>	
 ~*)	
-FUNCTION_BLOCK TcoTask EXTENDS TcoObject IMPLEMENTS ITcoTask
+FUNCTION_BLOCK TcoTask EXTENDS TcoObject IMPLEMENTS ITcoTask, ITcoTaskStatus
 VAR
 	{attribute clr [ReadOnly()]}
 	_taskState : eTaskState;
@@ -434,7 +434,7 @@ PROPERTY Identity : ULINT]]></Declaration>
 		</summary>			
 	</docu>	
 ~*)
-METHOD Invoke : ITcoTask
+METHOD Invoke : ITcoTaskStatus
 VAR
 	_newInvokeCall	:	BOOL;
 END_VAR]]></Declaration>

--- a/src/TcoCore/src/XaeTcoCore/TcoCore/TcoCore.plcproj
+++ b/src/TcoCore/src/XaeTcoCore/TcoCore/TcoCore.plcproj
@@ -127,6 +127,9 @@
     <Compile Include="POUs\Prototypes\TcoTask\eTaskState.TcDUT">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="POUs\Prototypes\TcoTask\ITcoTaskStatus.TcIO">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="POUs\Prototypes\TcoTask\ITcoTask.TcIO">
       <SubType>Code</SubType>
     </Compile>

--- a/src/TcoCore/src/XaeTcoCore/TcoCoreExamples/Examples/Manipulator/Components/fbPiston.TcPOU
+++ b/src/TcoCore/src/XaeTcoCore/TcoCoreExamples/Examples/Manipulator/Components/fbPiston.TcPOU
@@ -30,7 +30,7 @@ END_VAR
       </Implementation>
     </Method>
     <Method Name="MoveHome" Id="{ec08a57d-3edb-01f0-35bc-3c8a96242bb9}">
-      <Declaration><![CDATA[METHOD MoveHome : TcoCore.ITcoTask
+      <Declaration><![CDATA[METHOD MoveHome : TcoCore.ITcoTaskStatus
 
 ]]></Declaration>
       <Implementation>
@@ -38,7 +38,7 @@ END_VAR
       </Implementation>
     </Method>
     <Method Name="MoveWork" Id="{e9e0be0c-566d-0749-1c75-1097c8dadecf}">
-      <Declaration><![CDATA[METHOD MoveWork : TcoCore.ITcoTask]]></Declaration>
+      <Declaration><![CDATA[METHOD MoveWork : TcoCore.ITcoTaskStatus]]></Declaration>
       <Implementation>
         <ST><![CDATA[MoveWork := THIS^._moveWorkTask.Invoke();]]></ST>
       </Implementation>

--- a/src/TcoCore/src/XaeTcoCore/TcoCoreTests/Tests/TcoMessenger/TcoMessengerTests.TcPOU
+++ b/src/TcoCore/src/XaeTcoCore/TcoCoreTests/Tests/TcoMessenger/TcoMessengerTests.TcPOU
@@ -4,6 +4,7 @@
     <Declaration><![CDATA[FUNCTION_BLOCK TcoMessengerTests EXTENDS TcoCore.TcoObject
 VAR
 	_category : TcoCore.eMessageCategory;
+	_minLevel : TcoCore.eMessageCategory;
 END_VAR]]></Declaration>
     <Implementation>
       <ST><![CDATA[]]></ST>
@@ -106,6 +107,34 @@ END_VAR
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[_messenger.Programming(Message);]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="Resume" Id="{82062340-d28d-08df-1727-1ea7f90e73d2}">
+      <Declaration><![CDATA[{attribute 'TcRpcEnable'}
+METHOD PUBLIC Resume
+
+
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[Context.Environment.Messaging.Resume();]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="SetMinLevel" Id="{14062f88-3c36-0c8f-1769-35d9d0ae9a98}">
+      <Declaration><![CDATA[{attribute 'TcRpcEnable'}
+METHOD PUBLIC SetMinLevel
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[Context.Environment.Messaging.MinLevel := _minLevel;]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="Suspend" Id="{009042cd-d9d8-01ec-1e53-e01d1459f156}">
+      <Declaration><![CDATA[{attribute 'TcRpcEnable'}
+METHOD PUBLIC Suspend
+
+
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[Context.Environment.Messaging.Suspend();]]></ST>
       </Implementation>
     </Method>
     <Method Name="TimedOut" Id="{df75203d-ff31-0992-037d-6d10558ac6d6}">


### PR DESCRIPTION
#39  ITcoTask.Invoke returns reduced ```ITcoTaskStatus``` (Done, Busy, Error members) interface instead of ```ITcoStatus```.
#41 Implementation tests and API docu comments for Messaging settings
